### PR TITLE
Add basic OCR detector

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# OCR XL Detector
+
+This command-line application loads an image, maximizes its contrast,
+performs OCR using `pytesseract` and reports the number of occurrences
+of the contiguous letters `XL` (case-insensitive).
+
+```
+python -m src.ocr_app path/to/image.png
+```
+
+The script requires `Pillow` and `pytesseract` to be installed and
+`pytesseract` needs access to a Tesseract OCR binary.

--- a/src/ocr_app.py
+++ b/src/ocr_app.py
@@ -1,0 +1,58 @@
+import re
+from typing import Tuple
+
+try:
+    from PIL import Image, ImageOps, ImageEnhance
+except ImportError:  # pragma: no cover - Pillow not installed
+    Image = None
+
+try:
+    import pytesseract
+except ImportError:  # pragma: no cover - pytesseract not installed
+    pytesseract = None
+
+
+def load_image(path: str):
+    """Load an image from a file path."""
+    if Image is None:
+        raise RuntimeError("Pillow is required but not installed")
+    return Image.open(path)
+
+
+def enhance_contrast(image) -> 'Image.Image':
+    """Enhance image contrast to aid OCR."""
+    if ImageOps is None:
+        raise RuntimeError("Pillow is required but not installed")
+    # autocontrast maximises contrast based on image histogram
+    enhanced = ImageOps.autocontrast(image)
+    return enhanced
+
+
+def run_ocr(image) -> str:
+    """Run OCR on the provided image."""
+    if pytesseract is None:
+        raise RuntimeError("pytesseract is required but not installed")
+    return pytesseract.image_to_string(image)
+
+
+def find_xl(text: str) -> Tuple[bool, int]:
+    """Return whether 'XL' appears in text and how many times."""
+    matches = re.findall(r"xl", text, flags=re.IGNORECASE)
+    return bool(matches), len(matches)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="OCR XL detector")
+    parser.add_argument("image", help="Path to image file")
+    args = parser.parse_args()
+
+    img = load_image(args.image)
+    img = enhance_contrast(img)
+    text = run_ocr(img)
+    found, count = find_xl(text)
+    if found:
+        print(f"Found {count} occurrence(s) of 'XL'.")
+    else:
+        print("No 'XL' found.")

--- a/tests/test_ocr_app.py
+++ b/tests/test_ocr_app.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from ocr_app import find_xl
+
+
+def test_find_xl_detects_case_insensitive():
+    found, count = find_xl('xxl XL xl')
+    assert found
+    assert count == 3
+
+
+def test_find_xl_no_match():
+    found, count = find_xl('Hello world')
+    assert not found
+    assert count == 0


### PR DESCRIPTION
## Summary
- implement a simple OCR command-line tool
- add tests for the XL detection logic
- document usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876823aa98c83299219a37acd8f5c59