### PR TITLE
Update OCR to use AWS Rekognition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 # OCR XL Detector
 
 This command-line application loads an image, maximizes its contrast,
-performs OCR using `pytesseract` and reports the number of occurrences
+performs OCR using AWS Rekognition and reports the number of occurrences
 of the contiguous letters `XL` (case-insensitive).
 
 ```
 python -m src.ocr_app path/to/image.png
 ```
 
-The script requires `Pillow` and `pytesseract` to be installed and
-`pytesseract` needs access to a Tesseract OCR binary.
+The script requires `Pillow` and `boto3` to be installed and
+valid AWS credentials with access to the Rekognition API.


### PR DESCRIPTION
## Summary
- use AWS Rekognition detect_text in `run_ocr`
- document Rekognition requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687687768ae8832999809a48bd70ffca