### PR TITLE
Add AWS region fallback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,7 @@ python -m src.ocr_app path/to/image.png
 
 The script requires `Pillow` and `boto3` to be installed and
 valid AWS credentials with access to the Rekognition API.
+
+AWS operations require a region. The application will look for the
+`AWS_REGION` or `AWS_DEFAULT_REGION` environment variable and defaults to
+`us-east-1` when none is specified.

--- a/src/ocr_app.py
+++ b/src/ocr_app.py
@@ -39,7 +39,14 @@ def run_ocr(image) -> str:
     image.save(buffer, format=fmt)
     image_bytes = buffer.getvalue()
 
-    client = boto3.client("rekognition")
+    import os
+
+    region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-east-1"
+    )
+    client = boto3.client("rekognition", region_name=region)
     response = client.detect_text(Image={"Bytes": image_bytes})
     detections = response.get("TextDetections", [])
     text = " ".join(d.get("DetectedText", "") for d in detections)


### PR DESCRIPTION
## Summary
- default to region from environment or `us-east-1`
- document how the region is determined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687692370fdc8329bde79a75f0838bac