### PR TITLE
Add CSV output for folder scans

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,12 @@ of the contiguous letters `XL` (case-insensitive).
 python -m src.ocr_app path/to/image.png
 ```
 
+To scan all images in a directory and write the results to a CSV file:
+
+```
+python -m src.ocr_app path/to/folder --csv results.csv
+```
+
 The script requires `Pillow` and `boto3` to be installed and
 valid AWS credentials with access to the Rekognition API.
 

--- a/tests/test_ocr_app.py
+++ b/tests/test_ocr_app.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
-from ocr_app import find_xl
+from ocr_app import find_xl, main
 
 
 def test_find_xl_detects_case_insensitive():
@@ -16,3 +16,28 @@ def test_find_xl_no_match():
     found, count = find_xl('Hello world')
     assert not found
     assert count == 0
+
+
+def test_main_processes_directory(tmp_path, monkeypatch):
+    images = tmp_path / "imgs"
+    images.mkdir()
+    (images / "one.png").write_text("data")
+    (images / "two.jpg").write_text("data")
+
+    def fake_process(path):
+        if path.endswith("one.png"):
+            return True, 2
+        return False, 0
+
+    monkeypatch.setattr("ocr_app.process_image_file", fake_process)
+    csv_file = tmp_path / "out.csv"
+    main([str(images), "--csv", str(csv_file)])
+
+    import csv
+
+    with open(csv_file, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+
+    assert any(row["file"].endswith("one.png") and row["found"] == "True" and row["count"] == "2" for row in rows)
+    assert any(row["file"].endswith("two.jpg") and row["found"] == "False" and row["count"] == "0" for row in rows)
+


### PR DESCRIPTION
## Summary
- enable processing directories of images
- write OCR results to CSV when requested
- document directory scanning functionality
- test directory handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687694531050832985ab7aa08121684e